### PR TITLE
fix: reset parser state in StreamParser::next

### DIFF
--- a/include/internal/basic_csv_parser.hpp
+++ b/include/internal/basic_csv_parser.hpp
@@ -320,6 +320,9 @@ namespace csv {
             void next(size_t bytes = ITERATION_CHUNK_SIZE) override {
                 if (this->eof()) return;
 
+                // Reset parser state
+                this->field_start = UNINITIALIZED_FIELD;
+                this->field_length = 0;
                 this->reset_data_ptr();
                 this->data_ptr->_stream_pos = this->stream_pos;
                 this->data_ptr->_data = std::make_shared<std::string>();

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -6165,6 +6165,9 @@ namespace csv {
             void next(size_t bytes = ITERATION_CHUNK_SIZE) override {
                 if (this->eof()) return;
 
+                // Reset parser state
+                this->field_start = UNINITIALIZED_FIELD;
+                this->field_length = 0;
                 this->reset_data_ptr();
                 this->data_ptr->_stream_pos = this->stream_pos;
                 this->data_ptr->_data = std::make_shared<std::string>();

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -6165,6 +6165,9 @@ namespace csv {
             void next(size_t bytes = ITERATION_CHUNK_SIZE) override {
                 if (this->eof()) return;
 
+                // Reset parser state
+                this->field_start = UNINITIALIZED_FIELD;
+                this->field_length = 0;
                 this->reset_data_ptr();
                 this->data_ptr->_stream_pos = this->stream_pos;
                 this->data_ptr->_data = std::make_shared<std::string>();


### PR DESCRIPTION
StreamParser::next was missing parsing state reset. It caused incorrectly parsing the first element of the second and later chunks. This commit addresses the issue.